### PR TITLE
Optimize chain weight calculation

### DIFF
--- a/bwamem.c
+++ b/bwamem.c
@@ -238,23 +238,20 @@ static int test_and_merge(const mem_opt_t *opt, int64_t l_pac, mem_chain_t *c, c
 
 int mem_chain_weight(const mem_chain_t *c)
 {
-	int64_t end;
-	int j, w = 0, tmp;
-	for (j = 0, end = 0; j < c->n; ++j) {
-		const mem_seed_t *s = &c->seeds[j];
-		if (s->qbeg >= end) w += s->len;
-		else if (s->qbeg + s->len > end) w += s->qbeg + s->len - end;
-		end = end > s->qbeg + s->len? end : s->qbeg + s->len;
-	}
-	tmp = w; w = 0;
-	for (j = 0, end = 0; j < c->n; ++j) {
-		const mem_seed_t *s = &c->seeds[j];
-		if (s->rbeg >= end) w += s->len;
-		else if (s->rbeg + s->len > end) w += s->rbeg + s->len - end;
-		end = end > s->rbeg + s->len? end : s->rbeg + s->len;
-	}
-	w = w < tmp? w : tmp;
-	return w < 1<<30? w : (1<<30)-1;
+    int64_t q_end = 0, r_end = 0;
+    int j, wq = 0, wr = 0;
+    for (j = 0; j < c->n; ++j) {
+        const mem_seed_t *s = &c->seeds[j];
+        if (s->qbeg >= q_end) wq += s->len;
+        else if (s->qbeg + s->len > q_end) wq += s->qbeg + s->len - q_end;
+        q_end = q_end > s->qbeg + s->len? q_end : s->qbeg + s->len;
+
+        if (s->rbeg >= r_end) wr += s->len;
+        else if (s->rbeg + s->len > r_end) wr += s->rbeg + s->len - r_end;
+        r_end = r_end > s->rbeg + s->len? r_end : s->rbeg + s->len;
+    }
+    int w = wq < wr? wq : wr;
+    return w < 1<<30? w : (1<<30)-1;
 }
 
 void mem_print_chain(const bntseq_t *bns, mem_chain_v *chn)


### PR DESCRIPTION
## Summary
- compress two loops in `mem_chain_weight()` into one

## Testing
- `make -j4`
- `./bwa 2>&1 | head -n 5`
